### PR TITLE
Support for optional `Limits` fields in the ECS metadata responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,12 @@ module github.com/rdforte/gomaxecs
 
 go 1.22.4
 
-require go.uber.org/automaxprocs v1.5.3
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,16 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,12 +32,8 @@ const metaURIEnv = "ECS_CONTAINER_METADATA_URI_V4"
 func New() Config {
 	uri := metadataURI()
 
-	pathParts := strings.Split(uri, "/")
-	containerID := pathParts[len(pathParts)-1]
-
 	return Config{
 		MetadataURI: uri,
-		ConainerID:  containerID,
 		Client: Client{
 			HTTPTimeout:           time.Second * 5,
 			DialTimeout:           time.Second,
@@ -52,13 +48,13 @@ func New() Config {
 }
 
 func metadataURI() string {
-	return os.Getenv(metaURIEnv)
+	uri := os.Getenv(metaURIEnv)
+	return strings.TrimRight(uri, "/")
 }
 
 // Config represents the packagge configuration.
 type Config struct {
 	MetadataURI string
-	ConainerID  string
 	Client      Client
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,7 +20,6 @@ func TestConfig_LoadConfiguration(t *testing.T) {
 
 	wantCfg := config.Config{
 		MetadataURI: uri,
-		ConainerID:  containerID,
 		Client: config.Client{
 			HTTPTimeout:           time.Second * 5,
 			DialTimeout:           time.Second,

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -93,7 +93,12 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 }
 
 func testServerContainerLimit(containerCPU, taskCPU int) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/container-id", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
+	})
+	mux.HandleFunc("/container-id/task", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf(`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`, containerCPU, taskCPU)))
-	}))
+	})
+	return httptest.NewServer(mux)
 }


### PR DESCRIPTION
`gomaxecs` was not setting the CPU limits correctly for my ECS containers when the `task/` endpoint did not include the Limits field in the main structure. For example, the current `gomaxecs` implementation assumes the following JSON for `task/`:

```json
{
  ...
  "Limits": {
    "CPU": 12,
    "Memory": 131072
  },
  "Containers": [
    {
      "CreatedAt": "2024-10-15T20:04:23.388043285Z",
      "DesiredStatus": "RUNNING",
      "DockerId": "3c5f7c2654d97632c2846401057e5799a2f66c4df0a277fbfb96b666d554e7b7",
      "Limits": {
        "CPU": 12288,
        "Memory": 131072
      }
    }
  ]
  ...
}
```

but I was routinely seeing the following:
```json
{
  ...
  "Containers": [
    {
      "CreatedAt": "2024-10-15T20:04:23.388043285Z",
      "DesiredStatus": "RUNNING",
      "DockerId": "3c5f7c2654d97632c2846401057e5799a2f66c4df0a277fbfb96b666d554e7b7",
      "Limits": {
        "CPU": 12288,
        "Memory": 131072
      }
    }
  ]
  ...
}
```

As it turns out, `Limits` is optional [according to the AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-response.html) and it doesn't show `Limits` in the `task/` [example](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-examples.html). Because empty values are 0 in Go, `gomaxecs` would always fail here:

https://github.com/rdforte/gomaxecs/blob/02885de04eebbebf19f04a57371448cda37e5baa/internal/task/task.go#L61-L63

This PR changes two things:
1. query both `$ECS_CONTAINER_METADATA_URI_V4` (container metadata) and `$ECS_CONTAINER_METADATA_URI_V4/task` (task metadata) and wrangle out the true limit: container limit if < task limit or if task limit is not available
2. use DockerIDs from the container metadata to match it to the correct element in the task metadata - this was failing before as the URI itself was never found in the task metadata in my case

All existing tests pass.