### PR TITLE
Set GOMAXPROCS=1 for less than 1 vCPU

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -89,6 +89,10 @@ func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 	}
 
 	cpu := int(containerCPULimit) >> cpuUnits
+	// Set a minimum of 1 for containers with less than 1 vCPU
+	if cpu == 0 {
+		cpu = 1
+	}
 
 	taskCPULimit := int(task.Limits.CPU)
 	if taskCPULimit > 0 {

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -47,6 +47,13 @@ func TestTask_GetMaxProcs_GetsCPUUsingContainerLimit(t *testing.T) {
 		testServer   func(t *testing.T, containerCPU, taskCPU int) *httptest.Server
 	}{
 		{
+			name:         "should get cpu of 1 when task CPU limit is 1 and container CPU limit is 512 vCPU",
+			wantCPU:      1,
+			containerCPU: 1 << 9,
+			taskCPU:      1,
+			testServer:   testServerContainerLimit,
+		},
+		{
 			name:         "should get cpu of 1 when task CPU limit is 1 and container CPU limit is 1024 vCPU",
 			wantCPU:      1,
 			containerCPU: 1 << 10,


### PR DESCRIPTION
Hi, while running in a ECS cluster, and giving 0.5 vCPU to my task, this result in putting `GOMAXPROCS=0`.

I am proposing to set a min `GOMAXPROCS` value to 1.

Open for propositions for this implementation.