### PR TITLE
Include undo and apply functional options pattern for setting logger

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,9 @@ issues:
     - path: gomaxecs.go
       linters:
         - gochecknoinits # enable init function for setting GOMAXPROCS.
+    - path: maxprocs/maxprocs_test.go
+      linters:
+        - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
 
 linters-settings:
   depguard:

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -29,5 +29,5 @@ import (
 )
 
 func init() {
-	maxprocs.Set(maxprocs.WithLogger(log.Printf))
+	_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
 }

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -29,5 +29,5 @@ import (
 )
 
 func init() {
-	maxprocs.Set(log.Default())
+	maxprocs.Set(maxprocs.WithLogger(log.Printf))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,7 @@ func New(opts ...Option) Config {
 	}
 
 	for _, opt := range opts {
-		opt.Apply(&cfg)
+		opt(&cfg)
 	}
 
 	return cfg
@@ -91,18 +91,12 @@ func (c Config) Log(format string, args ...any) {
 	}
 }
 
-// Option alters the behavior of the Config.
-type Option interface {
-	Apply(*Config)
-}
-
 // WithLogger sets the logger for the config.
 func WithLogger(logger logger) Option {
-	return option(func(cfg *Config) {
+	return func(cfg *Config) {
 		cfg.log = logger
-	})
+	}
 }
 
-type option func(*Config)
-
-func (opt option) Apply(cfg *Config) { opt(cfg) }
+// Option represents a configuration option for the config.
+type Option func(*Config)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ const (
 )
 
 func New(opts ...Option) Config {
-	uri := metadataURI()
+	uri := GetECSMetadataURI()
 
 	cfg := Config{
 		TaskMetadataURI:      uri + taskPath,
@@ -58,7 +58,8 @@ func New(opts ...Option) Config {
 	return cfg
 }
 
-func metadataURI() string {
+// GetECSMetadataURI returns the ECS metadata URI.
+func GetECSMetadataURI() string {
 	uri := os.Getenv(metaURIEnv)
 	return strings.TrimRight(uri, "/")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,8 @@ func TestConfig_New_LoadConfiguration(t *testing.T) {
 }
 
 func TestConfig_New_AppliesOptions(t *testing.T) {
+	t.Parallel()
+
 	opt1 := mockOption{}
 	opt2 := mockOption{}
 
@@ -48,6 +50,8 @@ func TestConfig_New_AppliesOptions(t *testing.T) {
 }
 
 func TestConfig_WithLogger(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	logger := log.New(buf, "", 0)
 
@@ -57,6 +61,17 @@ func TestConfig_WithLogger(t *testing.T) {
 
 	wantLog := "test log: arg1, arg2\n"
 	assert.Equal(t, wantLog, buf.String())
+}
+
+func TestConfig_GetECSMetadataURI_RetrievesMetadataURIFromEnv(t *testing.T) {
+	metaURIEnv := "ECS_CONTAINER_METADATA_URI_V4"
+	uri := "mock-ecs-metadata-uri/"
+	t.Setenv(metaURIEnv, uri)
+
+	got := config.GetECSMetadataURI()
+
+	want := "mock-ecs-metadata-uri"
+	assert.Equal(t, want, got)
 }
 
 type mockOption struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,7 +49,7 @@ func TestConfig_New_AppliesOptions(t *testing.T) {
 	assert.True(t, opt2.isApplied)
 }
 
-func TestConfig_WithLogger(t *testing.T) {
+func TestConfig_WithLogger_LogsMessage(t *testing.T) {
 	t.Parallel()
 
 	buf := new(bytes.Buffer)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,7 +41,7 @@ func TestConfig_New_AppliesOptions(t *testing.T) {
 	opt1 := mockOption{}
 	opt2 := mockOption{}
 
-	config.New(&opt1, &opt2)
+	config.New(opt1.Apply, opt2.Apply)
 
 	assert.True(t, opt1.isApplied)
 	assert.True(t, opt2.isApplied)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config_test
 
 import (
+	"bytes"
+	"log"
 	"testing"
 	"time"
 
@@ -9,7 +11,7 @@ import (
 	"github.com/rdforte/gomaxecs/internal/config"
 )
 
-func TestConfig_LoadConfiguration(t *testing.T) {
+func TestConfig_New_LoadConfiguration(t *testing.T) {
 	metaURIEnv := "ECS_CONTAINER_METADATA_URI_V4"
 	uri := "mock-ecs-metadata-uri/"
 	t.Setenv(metaURIEnv, uri)
@@ -33,4 +35,34 @@ func TestConfig_LoadConfiguration(t *testing.T) {
 	}
 
 	assert.Equal(t, wantCfg, cfg)
+}
+
+func TestConfig_New_AppliesOptions(t *testing.T) {
+	opt1 := mockOption{}
+	opt2 := mockOption{}
+
+	config.New(&opt1, &opt2)
+
+	assert.True(t, opt1.isApplied)
+	assert.True(t, opt2.isApplied)
+}
+
+func TestConfig_WithLogger(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logger := log.New(buf, "", 0)
+
+	cfg := config.New(config.WithLogger(logger.Printf))
+
+	cfg.Log("test log: %s, %s", "arg1", "arg2")
+
+	wantLog := "test log: arg1, arg2\n"
+	assert.Equal(t, wantLog, buf.String())
+}
+
+type mockOption struct {
+	isApplied bool
+}
+
+func (m *mockOption) Apply(_ *config.Config) {
+	m.isApplied = true
 }

--- a/internal/task/meta.go
+++ b/internal/task/meta.go
@@ -29,20 +29,20 @@ import (
 	"github.com/rdforte/gomaxecs/internal/client"
 )
 
-// TaskMeta represents the ECS Task Metadata.
+// taskMeta represents the ECS Task Metadata.
 type taskMeta struct {
 	Containers []container `json:"Containers"`
 	Limits     limit       `json:"Limits"` // this is optional in the response
 }
 
-// Container represents the ECS Container Metadata.
+// container represents the ECS Container Metadata.
 type container struct {
 	//nolint:tagliatelle // ECS Agent inconsistency. All fields adhere to goPascal but this one.
 	DockerID string `json:"DockerId"`
 	Limits   limit  `json:"Limits"`
 }
 
-// Limit contains the CPU limit.
+// limit contains the CPU limit.
 type limit struct {
 	CPU float64 `json:"CPU"`
 }

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	cpuUnits = 10
+	minCPU   = 1
 )
 
 var errNoCPULimit = errors.New("no CPU limit found for task or container")
@@ -84,15 +85,10 @@ func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 	}
 
 	if containerCPULimit == 0 {
-		minThreads := 1
-		return max(int(task.Limits.CPU), minThreads), nil
+		return max(int(task.Limits.CPU), minCPU), nil
 	}
 
-	cpu := int(containerCPULimit) >> cpuUnits
-	// Set a minimum of 1 for containers with less than 1 vCPU
-	if cpu == 0 {
-		cpu = 1
-	}
+	cpu := max(int(containerCPULimit)>>cpuUnits, minCPU)
 
 	taskCPULimit := int(task.Limits.CPU)
 	if taskCPULimit > 0 {

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -158,6 +158,8 @@ func TestTask_GetMaxProcs_GetsCPUUsingContainerLimit(t *testing.T) {
 			taskCPU:      16,
 			testServer:   testServerContainerLimit,
 		},
+		// For tasks that are hosted on Amazon EC2 instances, the CPU limit is optional.
+		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
 		{
 			name:         "should get cpu of 16 when task CPU limit is 0 and container CPU limit is 16384 vCPU",
 			wantCPU:      16,

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -22,7 +22,7 @@ func Set(opts ...config.Option) (func(), error) {
 		cfg.Log("maxprocs: No GOMAXPROCS change to reset")
 	}
 
-	if curMaxProcs, exists := honorCurrentMaxProcs(); exists {
+	if curMaxProcs, ok := honorCurrentMaxProcs(); ok {
 		cfg.Log("maxprocs: Honoring GOMAXPROCS=%q as set in environment", curMaxProcs)
 		return undoNoop, nil
 	}

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 
 	"github.com/rdforte/gomaxecs/internal/config"
-	"github.com/rdforte/gomaxecs/internal/task"
+	ecstask "github.com/rdforte/gomaxecs/internal/task"
 )
 
 const maxProcsKey = "GOMAXPROCS"
@@ -16,7 +16,7 @@ const maxProcsKey = "GOMAXPROCS"
 // returns a function to reset GOMAXPROCS to its previous value and an error if one occurred.
 func Set(opts ...config.Option) (func(), error) {
 	cfg := config.New(opts...)
-	ecsTask := task.New(cfg)
+	task := ecstask.New(cfg)
 
 	undoNoop := func() {
 		cfg.Log("maxprocs: No GOMAXPROCS change to reset")
@@ -33,7 +33,7 @@ func Set(opts ...config.Option) (func(), error) {
 		runtime.GOMAXPROCS(prevProcs)
 	}
 
-	procs, err := ecsTask.GetMaxProcs(context.Background())
+	procs, err := task.GetMaxProcs(context.Background())
 	if err != nil {
 		cfg.Log("maxprocs: Failed to set GOMAXPROCS:", err)
 		return undo, fmt.Errorf("failed to set GOMAXPROCS: %w", err)

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -2,24 +2,57 @@ package maxprocs
 
 import (
 	"context"
-	"log"
+	"os"
 	"runtime"
 
 	"github.com/rdforte/gomaxecs/internal/config"
 	"github.com/rdforte/gomaxecs/internal/task"
 )
 
+const maxProcsKey = "GOMAXPROCS"
+
 // Set sets GOMAXPROCS based on the CPU limit of the container and the task.
-func Set(log *log.Logger) {
-	cfg := config.New()
+// returns a function to reset GOMAXPROCS to its previous value and an error if any.
+func Set(opts ...config.Option) (func(), error) {
+	cfg := config.New(opts...)
 	t := task.New(cfg)
+
+	undoNoop := func() {
+		cfg.Log("maxprocs: No GOMAXPROCS change to reset")
+	}
+
+	if curMaxProcs, exists := honorCurrentMaxProcs(); exists {
+		cfg.Log("maxprocs: Honoring GOMAXPROCS=%q as set in environment", curMaxProcs)
+		return undoNoop, nil
+	}
+
+	prevProcs := currentMaxProcs()
+	undo := func() {
+		cfg.Log("maxprocs: Resetting GOMAXPROCS to %v", prevProcs)
+		runtime.GOMAXPROCS(prevProcs)
+	}
 
 	procs, err := t.GetMaxProcs(context.Background())
 	if err != nil {
-		log.Println("failed to set GOMAXPROCS:", err)
-		return
+		cfg.Log("maxprocs: Failed to set GOMAXPROCS:", err)
+		return undo, err
 	}
 
 	runtime.GOMAXPROCS(procs)
-	log.Println("GOMAXPROCS set to:", procs)
+	cfg.Log("maxprocs: Updating GOMAXPROCS=%v", procs)
+
+	return undo, nil
+}
+
+func honorCurrentMaxProcs() (string, bool) {
+	return os.LookupEnv(maxProcsKey)
+}
+
+func currentMaxProcs() int {
+	return runtime.GOMAXPROCS(0)
+}
+
+// WithLogger sets the logger. By default, no logger is set.
+func WithLogger(printf func(format string, args ...any)) config.Option {
+	return config.WithLogger(printf)
 }

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -27,7 +27,7 @@ func Set(opts ...config.Option) (func(), error) {
 		return undoNoop, nil
 	}
 
-	prevProcs := currentMaxProcs()
+	prevProcs := prevMaxProcs()
 	undo := func() {
 		cfg.Log("maxprocs: Resetting GOMAXPROCS to %v", prevProcs)
 		runtime.GOMAXPROCS(prevProcs)
@@ -49,7 +49,7 @@ func honorCurrentMaxProcs() (string, bool) {
 	return os.LookupEnv(maxProcsKey)
 }
 
-func currentMaxProcs() int {
+func prevMaxProcs() int {
 	return runtime.GOMAXPROCS(0)
 }
 

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -3,13 +3,11 @@ package maxprocs_test
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +17,6 @@ import (
 
 const (
 	metaURIEnv   = "ECS_CONTAINER_METADATA_URI_V4"
-	containerID  = "container-id"
 	taskCPU      = 8
 	containerCPU = 2 << 10
 )
@@ -36,9 +33,9 @@ func TestMaxProcs_Set_SuccessfullySetsGOMAXPROCS(t *testing.T) {
 	ts := testServerContainerLimit(t, 2<<10, 8)
 	defer ts.Close()
 
-	t.Setenv(metaURIEnv, strings.Join([]string{ts.URL, "/", containerID}, ""))
+	t.Setenv(metaURIEnv, ts.URL)
 
-	maxprocs.Set(log.New(io.Discard, "", 0))
+	maxprocs.Set()
 
 	procs := runtime.GOMAXPROCS(0)
 	wantProcs := 2
@@ -49,53 +46,110 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 	tableTest := []struct {
 		name    string
 		wantLog string
-		metaURI func() string
+		setup   func(t *testing.T)
 	}{
 		{
-			name:    "should log GOMAXPROCS value when successfully set",
-			wantLog: "GOMAXPROCS set to: 2",
-			metaURI: func() string {
+			name:    "should log when honours current max procs",
+			wantLog: "maxprocs: Honoring GOMAXPROCS=\"4\" as set in environment",
+			setup: func(t *testing.T) {
+				t.Setenv("GOMAXPROCS", "4")
+			},
+		},
+		{
+			name:    "should log GOMAXPROCS value when container cpu limit successfully set",
+			wantLog: "maxprocs: Updating GOMAXPROCS=2",
+			setup: func(t *testing.T) {
 				ts := testServerContainerLimit(t, 2<<10, 8)
 				t.Cleanup(ts.Close)
 
-				return strings.Join([]string{ts.URL, "/", containerID}, "")
+				t.Setenv(metaURIEnv, ts.URL)
+			},
+		},
+		{
+			name:    "should log GOMAXPROCS value when task cpu limit successfully set",
+			wantLog: "maxprocs: Updating GOMAXPROCS=8",
+			setup: func(t *testing.T) {
+				ts := testServerContainerLimit(t, 0, 8)
+				t.Cleanup(ts.Close)
+
+				t.Setenv(metaURIEnv, ts.URL)
 			},
 		},
 		{
 			name:    "should log error when fail to get max procs",
-			wantLog: "failed to set GOMAXPROC",
-			metaURI: func() string {
+			wantLog: "maxprocs: Failed to set GOMAXPROCS",
+			setup: func(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusInternalServerError)
 				}))
 				t.Cleanup(ts.Close)
 
-				return strings.Join([]string{ts.URL, "/", containerID}, "")
+				t.Setenv(metaURIEnv, ts.URL)
 			},
 		},
 	}
 
 	for _, tt := range tableTest {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(metaURIEnv, tt.metaURI())
+			tt.setup(t)
 
 			buf := new(bytes.Buffer)
-			maxprocs.Set(log.New(buf, "", 0))
+			logger := log.New(buf, "", 0)
+			maxprocs.Set(maxprocs.WithLogger(logger.Printf))
 
 			assert.Contains(t, buf.String(), tt.wantLog)
 		})
 	}
 }
 
+func TestMaxProcs_Set_UndoLogsNoChangesWhenHonoursCurrentMaxProcs(t *testing.T) {
+	t.Setenv("GOMAXPROCS", "4")
+
+	buf := new(bytes.Buffer)
+	logger := log.New(buf, "", 0)
+
+	undo, _ := maxprocs.Set(maxprocs.WithLogger(logger.Printf))
+
+	undo()
+
+	assert.Contains(t, buf.String(), "maxprocs: No GOMAXPROCS change to reset")
+}
+
+func TestMaxProcs_Set_UndoResetsGOMAXPROCS(t *testing.T) {
+	initialProcs := 5
+	runtime.GOMAXPROCS(initialProcs)
+
+	taskCPU := 8
+	containerCPU := 0
+
+	ts := testServerContainerLimit(t, containerCPU, taskCPU)
+	defer ts.Close()
+
+	t.Setenv(metaURIEnv, ts.URL)
+
+	buf := new(bytes.Buffer)
+	logger := log.New(buf, "", 0)
+
+	undo, _ := maxprocs.Set(maxprocs.WithLogger(logger.Printf))
+
+	assert.Equal(t, taskCPU, runtime.GOMAXPROCS(0)) // GOMAXPROCS should be set to taskCPU
+
+	undo() // reset GOMAXPROCS
+
+	assert.Equal(t, initialProcs, runtime.GOMAXPROCS(0)) // GOMAXPROCS should be reset to initialProcs
+
+	assert.Contains(t, buf.String(), fmt.Sprintf("maxprocs: Resetting GOMAXPROCS to %v", initialProcs))
+}
+
 func testServerContainerLimit(t *testing.T, containerCPU, taskCPU int) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/container-id", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
 		assert.NoError(t, err)
 	})
-	mux.HandleFunc("/container-id/task", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf(
 			`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`,
 			containerCPU,

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -112,7 +112,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 	}
 }
 
-func TestMaxProcs_Set_UndoLogsNoChangesWhenHonoursCurrentMaxProcs(t *testing.T) {
+func TestMaxProcs_Set_UndoLogsNoChangesWhenHonorsCurrentMaxProcs(t *testing.T) {
 	t.Setenv("GOMAXPROCS", "4")
 
 	buf := new(bytes.Buffer)

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -60,7 +60,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 		},
 		{
 			name:    "should log GOMAXPROCS value when container cpu limit successfully set",
-			wantLog: "maxprocs: Updating GOMAXPROCS=2",
+			wantLog: "maxprocs: Updated GOMAXPROCS=2",
 			setup: func(t *testing.T) {
 				t.Helper()
 
@@ -72,7 +72,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 		},
 		{
 			name:    "should log GOMAXPROCS value when task cpu limit successfully set",
-			wantLog: "maxprocs: Updating GOMAXPROCS=8",
+			wantLog: "maxprocs: Updated GOMAXPROCS=8",
 			setup: func(t *testing.T) {
 				t.Helper()
 
@@ -112,7 +112,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 	}
 }
 
-func TestMaxProcs_Set_UndoLogsNoChangesWhenHonorsCurrentMaxProcs(t *testing.T) {
+func TestMaxProcs_Set_UndoLogsNoChangesWhenHonorsGOMAXPROCSEnv(t *testing.T) {
 	t.Setenv("GOMAXPROCS", "4")
 
 	buf := new(bytes.Buffer)

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -51,7 +51,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 		setup   func(t *testing.T)
 	}{
 		{
-			name:    "should log when honours current max procs",
+			name:    "should log when honors current max procs",
 			wantLog: "maxprocs: Honoring GOMAXPROCS=\"4\" as set in environment",
 			setup: func(t *testing.T) {
 				t.Helper()


### PR DESCRIPTION
## Description
This change is in accordance with Proposal 2 for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36814

This change extends the Set method by:
- returning the error and an undo function which is responsible for reverting GOMAXPROCS to its previous value.
- Applies functional options pattern to allow for extending the config
- Adds the WithLogger method which allows the client to add their own logger that adheres to Printf
- Checks to see if GOMAXPROCS env variable is already set and then honors it. 

Adds a new method `IsECS` to check if current process running in ECS.

## NOTES
For anyone using Set this does break their current usage of `Set`. So we can either add this change as a new method and bump the minor version or update the existing `Set` method and bump the major version.