### PR TITLE
Init function bypass Set when no ECS Environment detected

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,6 +125,9 @@ issues:
     - path: maxprocs/maxprocs_test.go
       linters:
         - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
+    - path: gomaxecs_test.go
+      linters:
+        - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
 
 linters-settings:
   depguard:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: cover
 cover:
-	go test -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
+	go test --race -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: lint

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -35,5 +35,7 @@ func init() {
 func runSetMaxProcs() {
 	if maxprocs.IsECS() {
 		_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
+	} else {
+		log.Printf("maxprocs: ECS environment not detected")
 	}
 }

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -29,5 +29,11 @@ import (
 )
 
 func init() {
-	_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
+	runSetMaxProcs()
+}
+
+func runSetMaxProcs() {
+	if maxprocs.IsECS() {
+		_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
+	}
 }

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -36,6 +36,6 @@ func runSetMaxProcs() {
 	if maxprocs.IsECS() {
 		_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
 	} else {
-		log.Printf("maxprocs: ECS environment not detected")
+		log.Printf("maxprocs: ECS environment not detected. Skipping set GOMAXPROCS")
 	}
 }

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -36,6 +36,6 @@ func runSetMaxProcs() {
 	if maxprocs.IsECS() {
 		_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
 	} else {
-		log.Printf("maxprocs: ECS environment not detected. Skipping set GOMAXPROCS")
+		log.Printf("gomaxecs: ECS environment not detected. Skipping set GOMAXPROCS")
 	}
 }

--- a/gomaxecs_test.go
+++ b/gomaxecs_test.go
@@ -18,7 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package gomaxecs
+// NOTE: This file is intentionally testing a private function.
+// This is to ensure that the function runSetMaxProcs is tested
+// and remains private to the package.
+package gomaxecs //nolint:testpackage // Test private function.
 
 import (
 	"runtime"
@@ -30,8 +33,12 @@ import (
 )
 
 func TestGomaxecs_runSetMaxProcs_ECSEnvNotDetected(t *testing.T) {
+	t.Parallel()
+
 	curMaxProcs := runtime.GOMAXPROCS(0)
+
 	runSetMaxProcs()
+
 	assert.Equal(t, curMaxProcs, runtime.GOMAXPROCS(0))
 }
 
@@ -42,12 +49,12 @@ func TestGomaxecs_runSetMaxProcs_ECSEnvDetected(t *testing.T) {
 	wantCPUs := 2
 	containerCPU, taskCPU := wantCPUs<<10, wantCPUs
 
-	a := tasktest.NewECSAgent(t).
+	agent := tasktest.NewECSAgent(t).
 		WithContainerMetaEndpoint(containerCPU).
 		WithTaskMetaEndpoint(containerCPU, taskCPU).
 		Start().
 		SetMetaURIEnv()
-	defer a.Close()
+	defer agent.Close()
 
 	runSetMaxProcs()
 

--- a/gomaxecs_test.go
+++ b/gomaxecs_test.go
@@ -21,6 +21,7 @@
 // NOTE: This file is intentionally testing a private function.
 // This is to ensure that the function runSetMaxProcs is tested
 // and remains private to the package.
+
 package gomaxecs //nolint:testpackage // Test private function.
 
 import (

--- a/gomaxecs_test.go
+++ b/gomaxecs_test.go
@@ -18,7 +18,50 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Validate init function builds as expected.
-package gomaxecs_test
+package gomaxecs
 
-import _ "github.com/rdforte/gomaxecs"
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGomaxecs_runSetMaxProcs_NoECSEnvDetected(t *testing.T) {
+	curMaxProcs := runtime.GOMAXPROCS(0)
+	runSetMaxProcs()
+	assert.Equal(t, curMaxProcs, runtime.GOMAXPROCS(0))
+}
+
+func TestGomaxecs_runSetMaxProcs_ECSEnvDetected(t *testing.T) {
+	curMaxProcs := 1
+	runtime.GOMAXPROCS(curMaxProcs)
+	// set env variable to simulate ECS environment
+	ts := testServerContainerLimit(t, 2<<10, 2)
+	t.Setenv("ECS_CONTAINER_METADATA_URI_V4", ts.URL)
+	runSetMaxProcs()
+	assert.Equal(t, 2, runtime.GOMAXPROCS(0))
+}
+
+func testServerContainerLimit(t *testing.T, containerCPU, taskCPU int) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
+		assert.NoError(t, err)
+	})
+	mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(fmt.Sprintf(
+			`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`,
+			containerCPU,
+			taskCPU,
+		)))
+		assert.NoError(t, err)
+	})
+
+	return httptest.NewServer(mux)
+}

--- a/gomaxecs_test.go
+++ b/gomaxecs_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/rdforte/gomaxecs/internal/test/agent"
+	"github.com/rdforte/gomaxecs/internal/task/tasktest"
 )
 
 func TestGomaxecs_runSetMaxProcs_ECSEnvNotDetected(t *testing.T) {
@@ -42,7 +42,7 @@ func TestGomaxecs_runSetMaxProcs_ECSEnvDetected(t *testing.T) {
 	wantCPUs := 2
 	containerCPU, taskCPU := wantCPUs<<10, wantCPUs
 
-	a := agent.NewV4Builder(t).
+	a := tasktest.NewECSAgent(t).
 		WithContainerMetaEndpoint(containerCPU).
 		WithTaskMetaEndpoint(containerCPU, taskCPU).
 		Start().

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -178,52 +178,44 @@ func TestTask_GetMaxProcs_GetsCPUUsingTaskLimit(t *testing.T) {
 	t.Parallel()
 
 	tableTest := []struct {
-		name       string
-		wantCPU    int
-		taskCPU    int
-		testServer func(t *testing.T, taskCPU int) *httptest.Server
+		name    string
+		wantCPU int
+		taskCPU int
 	}{
 		{
-			name:       "should get cpu of 1 when task CPU limit is 0.25 and no container CPU limit set",
-			wantCPU:    1,
-			taskCPU:    1,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 1 when task CPU limit is 0.25 and no container CPU limit set",
+			wantCPU: 1,
+			taskCPU: 1,
 		},
 		{
-			name:       "should get cpu of 1 when task CPU limit is 0.5 and no container CPU limit set",
-			wantCPU:    1,
-			taskCPU:    1,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 1 when task CPU limit is 0.5 and no container CPU limit set",
+			wantCPU: 1,
+			taskCPU: 1,
 		},
 		{
-			name:       "should get cpu of 1 when task CPU limit is 1 and no container CPU limit set",
-			wantCPU:    1,
-			taskCPU:    1,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 1 when task CPU limit is 1 and no container CPU limit set",
+			wantCPU: 1,
+			taskCPU: 1,
 		},
 		{
-			name:       "should get cpu of 2 when task CPU limit is 2 and no container CPU limit set",
-			wantCPU:    2,
-			taskCPU:    2,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 2 when task CPU limit is 2 and no container CPU limit set",
+			wantCPU: 2,
+			taskCPU: 2,
 		},
 		{
-			name:       "should get cpu of 4 when task CPU limit is 4 and no container CPU limit set",
-			wantCPU:    4,
-			taskCPU:    4,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 4 when task CPU limit is 4 and no container CPU limit set",
+			wantCPU: 4,
+			taskCPU: 4,
 		},
 		{
-			name:       "should get cpu of 8 when task CPU limit is 8 and no container CPU limit set",
-			wantCPU:    8,
-			taskCPU:    8,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 8 when task CPU limit is 8 and no container CPU limit set",
+			wantCPU: 8,
+			taskCPU: 8,
 		},
 		{
-			name:       "should get cpu of 16 when task CPU limit is 16 and no container CPU limit set",
-			wantCPU:    16,
-			taskCPU:    16,
-			testServer: testServerTaskLimit,
+			name:    "should get cpu of 16 when task CPU limit is 16 and no container CPU limit set",
+			wantCPU: 16,
+			taskCPU: 16,
 		},
 	}
 

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/rdforte/gomaxecs/internal/config"
 	"github.com/rdforte/gomaxecs/internal/task"
-	"github.com/rdforte/gomaxecs/internal/test/agent"
+	"github.com/rdforte/gomaxecs/internal/task/tasktest"
 )
 
 const taskMetaPath = "/task"
@@ -156,7 +156,7 @@ func TestTask_GetMaxProcs_GetsCPUUsingContainerLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			a := agent.NewV4Builder(t).
+			a := tasktest.NewECSAgent(t).
 				WithContainerMetaEndpoint(tt.containerCPU).
 				WithTaskMetaEndpoint(tt.containerCPU, tt.taskCPU).
 				Start()
@@ -223,7 +223,7 @@ func TestTask_GetMaxProcs_GetsCPUUsingTaskLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			a := agent.NewV4Builder(t).
+			a := tasktest.NewECSAgent(t).
 				WithContainerMetaEndpoint(0).
 				WithTaskMetaEndpoint(0, tt.taskCPU).
 				Start()

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -231,13 +231,16 @@ func TestTask_GetMaxProcs_GetsCPUUsingTaskLimit(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// a := agent.NewV4Builder(t).
+			a := agent.NewV4Builder(t).
+				WithContainerMetaEndpoint(0).
+				WithTaskMetaEndpoint(0, tt.taskCPU).
+				Start()
+			defer a.Close()
 
-			ts := tt.testServer(t, tt.taskCPU)
-			defer ts.Close()
-
-			containerURI, taskURI := buildMetaEndpoints(ts)
-			ecsTask := task.New(config.Config{ContainerMetadataURI: containerURI, TaskMetadataURI: taskURI})
+			ecsTask := task.New(config.Config{
+				ContainerMetadataURI: a.GetContainerMetaEndpoint(),
+				TaskMetadataURI:      a.GetTaskMetaEndpoint(),
+			})
 
 			gotCPU, err := ecsTask.GetMaxProcs(context.Background())
 			require.NoError(t, err)

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -26,23 +26,28 @@ type ECSAgent struct {
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
 func NewECSAgent(t *testing.T) *ECSAgent {
 	t.Helper()
+
 	mux := http.NewServeMux()
+
 	return &ECSAgent{t, mux, nil, 0}
 }
 
 // WithContainerMetaEndpoint sets up the container CPU endpoint on the test server.
 func (e *ECSAgent) WithContainerMetaEndpoint(containerCPU int) *ECSAgent {
 	e.t.Helper()
+
 	e.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
 		assert.NoError(e.t, err)
 	})
+
 	return e
 }
 
 // WithTaskMetaEndpoint sets up the task CPU endpoint on the test server.
 func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 	e.t.Helper()
+
 	e.mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf(
 			`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`,
@@ -51,24 +56,29 @@ func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 		)))
 		assert.NoError(e.t, err)
 	})
+
 	return e
 }
 
 // WithContainerMetaEndpointInternalServerError sets up the container meta endpoint to return an internal server error.
 func (e *ECSAgent) WithContainerMetaEndpointInternalServerError() *ECSAgent {
 	e.t.Helper()
+
 	e.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
+
 	return e
 }
 
 // WithTaskMetaEndpointInternalServerError sets up the task meta endpoint to return an internal server error.
 func (e *ECSAgent) WithTaskMetaEndpointInternalServerError() *ECSAgent {
 	e.t.Helper()
+
 	e.mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
+
 	return e
 }
 
@@ -76,6 +86,7 @@ func (e *ECSAgent) WithTaskMetaEndpointInternalServerError() *ECSAgent {
 func (e *ECSAgent) WithContainerMetaEndpointInvalidJSON() *ECSAgent {
 	e.t.Helper()
 	e.mux.HandleFunc("/", e.invalidJSONHandler)
+
 	return e
 }
 
@@ -83,6 +94,7 @@ func (e *ECSAgent) WithContainerMetaEndpointInvalidJSON() *ECSAgent {
 func (e *ECSAgent) WithTaskMetaEndpointInvalidJSON() *ECSAgent {
 	e.t.Helper()
 	e.mux.HandleFunc(taskMetaPath, e.invalidJSONHandler)
+
 	return e
 }
 
@@ -95,6 +107,7 @@ func (e *ECSAgent) invalidJSONHandler(w http.ResponseWriter, _ *http.Request) {
 func (e *ECSAgent) Start() *ECSAgent {
 	e.t.Helper()
 	e.server = httptest.NewServer(e.mux)
+
 	return e
 }
 
@@ -102,22 +115,27 @@ func (e *ECSAgent) Start() *ECSAgent {
 // This is useful for testing the ECS metadata API.
 func (e *ECSAgent) SetMetaURIEnv() *ECSAgent {
 	e.t.Helper()
+
 	assert.NotNil(e.t, e.server)
 	e.t.Setenv(metaURIEnv, e.server.URL)
+
 	return e
 }
 
 // Close closes the test server.
 func (e *ECSAgent) Close() {
+	e.t.Helper()
 	e.server.Close()
 }
 
 // GetContainerMetaEndpoint returns the container metadata endpoint.
 func (e *ECSAgent) GetContainerMetaEndpoint() string {
+	e.t.Helper()
 	return e.server.URL
 }
 
 // GetTaskMetaEndpoint returns the task metadata endpoint.
 func (e *ECSAgent) GetTaskMetaEndpoint() string {
+	e.t.Helper()
 	return e.server.URL + taskMetaPath
 }

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -26,7 +26,6 @@ type ECSAgent struct {
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
 func NewECSAgent(t *testing.T) *ECSAgent {
 	t.Helper()
-
 	mux := http.NewServeMux()
 	return &ECSAgent{t, mux, nil, 0}
 }
@@ -51,6 +50,24 @@ func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 			taskCPU,
 		)))
 		assert.NoError(e.t, err)
+	})
+	return e
+}
+
+// WithContainerMetaEndpointInternalServerError sets up the container meta endpoint to return an internal server error.
+func (e *ECSAgent) WithContainerMetaEndpointInternalServerError() *ECSAgent {
+	e.t.Helper()
+	e.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	return e
+}
+
+// WithTaskMetaEndpointInternalServerError sets up the task meta endpoint to return an internal server error.
+func (e *ECSAgent) WithTaskMetaEndpointInternalServerError() *ECSAgent {
+	e.t.Helper()
+	e.mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
 	})
 	return e
 }

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -59,7 +59,8 @@ func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 	return e
 }
 
-// WithContainerMetaEndpointInternalServerError sets up the container metadata endpoint to return an internal server error.
+// WithContainerMetaEndpointInternalServerError sets up the container metadata endpoint
+// to return an internal server error.
 func (e *ECSAgent) WithContainerMetaEndpointInternalServerError() *ECSAgent {
 	e.t.Helper()
 

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -16,10 +16,9 @@ const (
 
 // ECSAgent is a test server that simulates the ECS Agent metadata API.
 type ECSAgent struct {
-	t            *testing.T
-	mux          *http.ServeMux
-	server       *httptest.Server
-	containerCPU int
+	t      *testing.T
+	mux    *http.ServeMux
+	server *httptest.Server
 }
 
 // NewECSAgent builds a new test server that simulates the ECS Agent metadata API.
@@ -29,7 +28,7 @@ func NewECSAgent(t *testing.T) *ECSAgent {
 
 	mux := http.NewServeMux()
 
-	return &ECSAgent{t, mux, nil, 0}
+	return &ECSAgent{t, mux, nil}
 }
 
 // WithContainerMetaEndpoint sets up the container CPU endpoint on the test server.

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -1,4 +1,4 @@
-package agent
+package tasktest
 
 import (
 	"fmt"
@@ -14,25 +14,25 @@ const (
 	taskMetaPath = "/task"
 )
 
-// ECSAgentV4 is a test server that simulates the ECS Agent metadata API.
-type ECSAgentV4 struct {
+// ECSAgent is a test server that simulates the ECS Agent metadata API.
+type ECSAgent struct {
 	t            *testing.T
 	mux          *http.ServeMux
 	server       *httptest.Server
 	containerCPU int
 }
 
-// NewBuilder builds a new test server that simulates the ECS Agent metadata API.
+// NewECSAgent builds a new test server that simulates the ECS Agent metadata API.
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
-func NewV4Builder(t *testing.T) *ECSAgentV4 {
+func NewECSAgent(t *testing.T) *ECSAgent {
 	t.Helper()
 
 	mux := http.NewServeMux()
-	return &ECSAgentV4{t, mux, nil, 0}
+	return &ECSAgent{t, mux, nil, 0}
 }
 
 // WithContainerMetaEndpoint sets up the container CPU endpoint on the test server.
-func (e *ECSAgentV4) WithContainerMetaEndpoint(containerCPU int) *ECSAgentV4 {
+func (e *ECSAgent) WithContainerMetaEndpoint(containerCPU int) *ECSAgent {
 	e.t.Helper()
 	e.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
@@ -42,7 +42,7 @@ func (e *ECSAgentV4) WithContainerMetaEndpoint(containerCPU int) *ECSAgentV4 {
 }
 
 // WithTaskMetaEndpoint sets up the task CPU endpoint on the test server.
-func (e *ECSAgentV4) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgentV4 {
+func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 	e.t.Helper()
 	e.mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(fmt.Sprintf(
@@ -56,7 +56,7 @@ func (e *ECSAgentV4) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgentV4
 }
 
 // Start starts the test server.
-func (e *ECSAgentV4) Start() *ECSAgentV4 {
+func (e *ECSAgent) Start() *ECSAgent {
 	e.t.Helper()
 	e.server = httptest.NewServer(e.mux)
 	return e
@@ -64,7 +64,7 @@ func (e *ECSAgentV4) Start() *ECSAgentV4 {
 
 // SetMetaURIEnv is a helper function to set the server url for ECS_CONTAINER_METADATA_URI_V4 environment variable.
 // This is useful for testing the ECS metadata API.
-func (e *ECSAgentV4) SetMetaURIEnv() *ECSAgentV4 {
+func (e *ECSAgent) SetMetaURIEnv() *ECSAgent {
 	e.t.Helper()
 	assert.NotNil(e.t, e.server)
 	e.t.Setenv(metaURIEnv, e.server.URL)
@@ -72,16 +72,16 @@ func (e *ECSAgentV4) SetMetaURIEnv() *ECSAgentV4 {
 }
 
 // Close closes the test server.
-func (e *ECSAgentV4) Close() {
+func (e *ECSAgent) Close() {
 	e.server.Close()
 }
 
 // GetContainerMetaEndpoint returns the container metadata endpoint.
-func (e *ECSAgentV4) GetContainerMetaEndpoint() string {
+func (e *ECSAgent) GetContainerMetaEndpoint() string {
 	return e.server.URL
 }
 
 // GetTaskMetaEndpoint returns the task metadata endpoint.
-func (e *ECSAgentV4) GetTaskMetaEndpoint() string {
+func (e *ECSAgent) GetTaskMetaEndpoint() string {
 	return e.server.URL + taskMetaPath
 }

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -72,6 +72,25 @@ func (e *ECSAgent) WithTaskMetaEndpointInternalServerError() *ECSAgent {
 	return e
 }
 
+// WithContainerMetaEndpointInvalidJSON sets up the container meta endpoint to return invalid JSON.
+func (e *ECSAgent) WithContainerMetaEndpointInvalidJSON() *ECSAgent {
+	e.t.Helper()
+	e.mux.HandleFunc("/", e.invalidJSONHandler)
+	return e
+}
+
+// WithTaskMetaEndpointInvalidJSON sets up the task meta endpoint to return invalid JSON.
+func (e *ECSAgent) WithTaskMetaEndpointInvalidJSON() *ECSAgent {
+	e.t.Helper()
+	e.mux.HandleFunc(taskMetaPath, e.invalidJSONHandler)
+	return e
+}
+
+func (e *ECSAgent) invalidJSONHandler(w http.ResponseWriter, _ *http.Request) {
+	_, err := w.Write([]byte("invlaid-json"))
+	assert.NoError(e.t, err)
+}
+
 // Start starts the test server.
 func (e *ECSAgent) Start() *ECSAgent {
 	e.t.Helper()

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -31,7 +31,7 @@ func NewECSAgent(t *testing.T) *ECSAgent {
 	return &ECSAgent{t, mux, nil}
 }
 
-// WithContainerMetaEndpoint sets up the container CPU endpoint on the test server.
+// WithContainerMetaEndpoint sets up the container metadata endpoint on the test server.
 func (e *ECSAgent) WithContainerMetaEndpoint(containerCPU int) *ECSAgent {
 	e.t.Helper()
 
@@ -43,7 +43,7 @@ func (e *ECSAgent) WithContainerMetaEndpoint(containerCPU int) *ECSAgent {
 	return e
 }
 
-// WithTaskMetaEndpoint sets up the task CPU endpoint on the test server.
+// WithTaskMetaEndpoint sets up the task metadata endpoint on the test server.
 func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 	e.t.Helper()
 
@@ -59,7 +59,7 @@ func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 	return e
 }
 
-// WithContainerMetaEndpointInternalServerError sets up the container meta endpoint to return an internal server error.
+// WithContainerMetaEndpointInternalServerError sets up the container metadata endpoint to return an internal server error.
 func (e *ECSAgent) WithContainerMetaEndpointInternalServerError() *ECSAgent {
 	e.t.Helper()
 
@@ -70,7 +70,7 @@ func (e *ECSAgent) WithContainerMetaEndpointInternalServerError() *ECSAgent {
 	return e
 }
 
-// WithTaskMetaEndpointInternalServerError sets up the task meta endpoint to return an internal server error.
+// WithTaskMetaEndpointInternalServerError sets up the task metadata endpoint to return an internal server error.
 func (e *ECSAgent) WithTaskMetaEndpointInternalServerError() *ECSAgent {
 	e.t.Helper()
 
@@ -81,7 +81,7 @@ func (e *ECSAgent) WithTaskMetaEndpointInternalServerError() *ECSAgent {
 	return e
 }
 
-// WithContainerMetaEndpointInvalidJSON sets up the container meta endpoint to return invalid JSON.
+// WithContainerMetaEndpointInvalidJSON sets up the container metadata endpoint to return invalid JSON.
 func (e *ECSAgent) WithContainerMetaEndpointInvalidJSON() *ECSAgent {
 	e.t.Helper()
 	e.mux.HandleFunc("/", e.invalidJSONHandler)
@@ -89,7 +89,7 @@ func (e *ECSAgent) WithContainerMetaEndpointInvalidJSON() *ECSAgent {
 	return e
 }
 
-// WithTaskMetaEndpointInvalidJSON sets up the task meta endpoint to return invalid JSON.
+// WithTaskMetaEndpointInvalidJSON sets up the task metadata endpoint to return invalid JSON.
 func (e *ECSAgent) WithTaskMetaEndpointInvalidJSON() *ECSAgent {
 	e.t.Helper()
 	e.mux.HandleFunc(taskMetaPath, e.invalidJSONHandler)

--- a/internal/test/agent/agent.go
+++ b/internal/test/agent/agent.go
@@ -55,24 +55,6 @@ func (e *ECSAgentV4) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgentV4
 	return e
 }
 
-// WithTaskMetaEndpointNoContainer sets up the task CPU endpoint on the test server without any container metadata.
-func (e *ECSAgentV4) WithTaskMetaEndpointNoContainer(containerCPU int) *ECSAgentV4 {
-	e.t.Helper()
-	e.mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(fmt.Sprintf(
-			`{"Containers":[{"DockerId":"container-id"}],"Limits":{"CPU":%d}}`,
-			containerCPU,
-		)))
-		assert.NoError(e.t, err)
-	})
-	return e
-}
-
-// return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-// _, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, taskCPU)))
-// assert.NoError(t, err)
-// }))
-
 // Start starts the test server.
 func (e *ECSAgentV4) Start() *ECSAgentV4 {
 	e.t.Helper()

--- a/internal/test/agent/agent.go
+++ b/internal/test/agent/agent.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ECSAgent struct {
+	server *httptest.Server
+	t      *testing.T
+}
+
+// New is a helper function to create a new test server that simulates
+// the ECS Agent metadata API.
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html
+func New(t *testing.T, containerCPU, taskCPU int) *ECSAgent {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
+		assert.NoError(t, err)
+	})
+	mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(fmt.Sprintf(
+			`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`,
+			containerCPU,
+			taskCPU,
+		)))
+		assert.NoError(t, err)
+	})
+
+	return &ECSAgent{httptest.NewServer(mux), t}
+}
+
+// SetServerURL is a helper function to set the server url for ECS_CONTAINER_METADATA_URI_V4 environment variable.
+// This is useful for testing the ECS metadata API.
+func (e *ECSAgent) SetServerURL() {
+	e.t.Helper()
+	e.t.Setenv("ECS_CONTAINER_METADATA_URI_V4", e.server.URL)
+}

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/rdforte/gomaxecs/internal/test/agent"
+	"github.com/rdforte/gomaxecs/internal/task/tasktest"
 	"github.com/rdforte/gomaxecs/maxprocs"
 )
 
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMaxProcs_Set_SuccessfullySetsGOMAXPROCS(t *testing.T) {
-	a := agent.NewV4Builder(t).
+	a := tasktest.NewECSAgent(t).
 		WithContainerMetaEndpoint(containerCPU).
 		WithTaskMetaEndpoint(containerCPU, taskCPU).
 		Start().
@@ -67,7 +67,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 			setup: func(t *testing.T) {
 				t.Helper()
 
-				a := agent.NewV4Builder(t).
+				a := tasktest.NewECSAgent(t).
 					WithContainerMetaEndpoint(containerCPU).
 					WithTaskMetaEndpoint(containerCPU, taskCPU).
 					Start().
@@ -83,7 +83,7 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 				t.Helper()
 
 				containerCPU := 0
-				a := agent.NewV4Builder(t).
+				a := tasktest.NewECSAgent(t).
 					WithContainerMetaEndpoint(containerCPU).
 					WithTaskMetaEndpoint(containerCPU, taskCPU).
 					Start().
@@ -142,7 +142,7 @@ func TestMaxProcs_Set_UndoResetsGOMAXPROCS(t *testing.T) {
 	taskCPU := 10
 	containerCPU := 0
 
-	a := agent.NewV4Builder(t).
+	a := tasktest.NewECSAgent(t).
 		WithContainerMetaEndpoint(containerCPU).
 		WithTaskMetaEndpoint(containerCPU, taskCPU).
 		Start().

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -32,12 +32,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestMaxProcs_Set_SuccessfullySetsGOMAXPROCS(t *testing.T) {
-	a := tasktest.NewECSAgent(t).
+	agent := tasktest.NewECSAgent(t).
 		WithContainerMetaEndpoint(containerCPU).
 		WithTaskMetaEndpoint(containerCPU, taskCPU).
 		Start().
 		SetMetaURIEnv()
-	defer a.Close()
+	defer agent.Close()
 
 	_, err := maxprocs.Set()
 	require.NoError(t, err)
@@ -67,13 +67,13 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 			setup: func(t *testing.T) {
 				t.Helper()
 
-				a := tasktest.NewECSAgent(t).
+				agent := tasktest.NewECSAgent(t).
 					WithContainerMetaEndpoint(containerCPU).
 					WithTaskMetaEndpoint(containerCPU, taskCPU).
 					Start().
 					SetMetaURIEnv()
 
-				t.Cleanup(a.Close)
+				t.Cleanup(agent.Close)
 			},
 		},
 		{
@@ -83,13 +83,13 @@ func TestMaxProcs_Set_LoggerShouldLog(t *testing.T) {
 				t.Helper()
 
 				containerCPU := 0
-				a := tasktest.NewECSAgent(t).
+				agent := tasktest.NewECSAgent(t).
 					WithContainerMetaEndpoint(containerCPU).
 					WithTaskMetaEndpoint(containerCPU, taskCPU).
 					Start().
 					SetMetaURIEnv()
 
-				t.Cleanup(a.Close)
+				t.Cleanup(agent.Close)
 			},
 		},
 		{
@@ -142,12 +142,12 @@ func TestMaxProcs_Set_UndoResetsGOMAXPROCS(t *testing.T) {
 	taskCPU := 10
 	containerCPU := 0
 
-	a := tasktest.NewECSAgent(t).
+	agent := tasktest.NewECSAgent(t).
 		WithContainerMetaEndpoint(containerCPU).
 		WithTaskMetaEndpoint(containerCPU, taskCPU).
 		Start().
 		SetMetaURIEnv()
-	defer a.Close()
+	defer agent.Close()
 
 	buf := new(bytes.Buffer)
 	logger := log.New(buf, "", 0)


### PR DESCRIPTION
## Description

- Utilises the `maxprocs.IsECS` method in the init function to detect if running in ECS. If no ECS environment is detected then it will bypass setting GOMAXPROCS. This is to ensure a better local development experience vs previously where it would log an error due to the absence of the ECS agent.

- Refactors code to use the ECSAgent test helper.

- runs test with the `--race` flag
