### PR TITLE
Add new debug support and bump go version to 1.25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,6 @@ jobs:
           verbose: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.60
+          version: v2.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          go-version: "1.25"
 
       - name: Build
         run: go build -v ./...
@@ -27,7 +27,7 @@ jobs:
         run: make cover
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           files: ./cover.html

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,7 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - asasalint
     - asasalint
     - asciicheck
     - bidichk
@@ -41,15 +38,11 @@ linters:
     - gocyclo
     - godot
     - godox
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - gosmopolitan
     - govet
     - grouper
@@ -88,10 +81,8 @@ linters:
     - spancheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
     - testpackage
@@ -105,50 +96,69 @@ linters:
     - wastedassign
     - whitespace
     - wrapcheck
-    - wsl
+    - wsl_v5
     - zerologlint
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - funlen
-        - dupl # Duplicated code is allowed in tests.
-        - gochecknoglobals # Globals are allowed in tests.
-        - containedctx
-        - maintidx
-        - ireturn
-        - cyclop
-    - path: gomaxecs.go
-      linters:
-        - gochecknoinits # enable init function for setting GOMAXPROCS.
-    - path: maxprocs/maxprocs_test.go
-      linters:
-        - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
-    - path: gomaxecs_test.go
-      linters:
-        - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        allow:
-          - "$gostd"
-          - "github.com/stretchr/testify"
-          - "github.com/rdforte/gomaxecs"
-  tagliatelle:
-    case:
+  settings:
+    depguard:
       rules:
-        json: goPascal
-  varnamelen:
-    min-name-length: 2
-  nlreturn:
-    block-size: 2
-  ireturn:
-    allow:
-      - generic
-      - anon
-      - error
-      - empty
-      - stdlib
+        main:
+          allow:
+            - $gostd
+            - github.com/stretchr/testify
+            - github.com/rdforte/gomaxecs
+    ireturn:
+      allow:
+        - generic
+        - anon
+        - error
+        - empty
+        - stdlib
+    nlreturn:
+      block-size: 2
+    tagliatelle:
+      case:
+        rules:
+          json: goPascal
+    varnamelen:
+      min-name-length: 2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - containedctx
+          - cyclop
+          - dupl # Duplicated code is allowed in tests.
+          - funlen
+          - gochecknoglobals # Globals are allowed in tests.
+          - ireturn
+          - maintidx
+        path: _test\.go
+      - linters:
+          - gochecknoinits # enable init function for setting GOMAXPROCS.
+        path: gomaxecs.go
+      - linters:
+          - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
+        path: maxprocs/maxprocs_test.go
+      - linters:
+          - paralleltest # disable paralleltest for testing GOMAXPROCS env variable.
+        path: gomaxecs_test.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ The below logs show that GOMAXPROCS is correctly set to 4 when using the **gomax
 | August 30, 2025 at 16:27 | GOMACPROCS: 4                                      | c2        |
 | August 30, 2025 at 16:27 | 2025/08/30 06:27:35 maxprocs: Updated GOMAXPROCS=4 | c2        |
 
+## Debugging
+
+To enable debug logging set the env variable `GOMAXECS_DEBUG` to `true` or `1`.
+
+```shell
+export GOMAXECS_DEBUG=true
+```
+
+or
+
+```shell
+export GOMAXECS_DEBUG=1
+```
+
+This will increase the verbosity of the logs output by the package and help with debugging any issues.
+
 ## Contribution
 
 If anyone has any good ideas on how this package can be improved, all contributions are welcome.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rdforte/gomaxecs
 
-go 1.22.4
+go 1.25
 
 require github.com/stretchr/testify v1.9.0
 

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -35,5 +35,7 @@ func init() {
 func runSetMaxProcs() {
 	if maxprocs.IsECS() {
 		_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
+	} else {
+		log.Printf("gomaxecs: ECS environment not detected. Skipping set GOMAXPROCS")
 	}
 }

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -29,9 +29,7 @@ import (
 )
 
 func init() {
-	log.Printf("gomaxecs: Starting calculation for GOMAXPROCS")
 	runSetMaxProcs()
-	log.Printf("gomaxecs: Finished calculation for GOMAXPROCS")
 }
 
 func runSetMaxProcs() {

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -35,7 +35,5 @@ func init() {
 func runSetMaxProcs() {
 	if maxprocs.IsECS() {
 		_, _ = maxprocs.Set(maxprocs.WithLogger(log.Printf))
-	} else {
-		log.Printf("gomaxecs: ECS environment not detected. Skipping set GOMAXPROCS")
 	}
 }

--- a/gomaxecs.go
+++ b/gomaxecs.go
@@ -29,7 +29,9 @@ import (
 )
 
 func init() {
+	log.Printf("gomaxecs: Starting calculation for GOMAXPROCS")
 	runSetMaxProcs()
+	log.Printf("gomaxecs: Finished calculation for GOMAXPROCS")
 }
 
 func runSetMaxProcs() {

--- a/gomaxecs_test.go
+++ b/gomaxecs_test.go
@@ -25,6 +25,8 @@
 package gomaxecs //nolint:testpackage // Test private function.
 
 import (
+	"bytes"
+	"log"
 	"runtime"
 	"testing"
 
@@ -36,11 +38,21 @@ import (
 func TestGomaxecs_runSetMaxProcs_ECSEnvNotDetected(t *testing.T) {
 	t.Parallel()
 
+	buf := new(bytes.Buffer)
+
+	// replace the original log.Printf with one that writes to our buffer
+	originalLogger := log.Default()
+	originalOutput := originalLogger.Writer()
+
+	log.SetOutput(buf)
+	defer log.SetOutput(originalOutput)
+
 	curMaxProcs := runtime.GOMAXPROCS(0)
 
 	runSetMaxProcs()
 
 	assert.Equal(t, curMaxProcs, runtime.GOMAXPROCS(0))
+	assert.Contains(t, buf.String(), "gomaxecs: ECS environment not detected. Skipping set GOMAXPROCS\n")
 }
 
 func TestGomaxecs_runSetMaxProcs_ECSEnvDetected(t *testing.T) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -34,7 +34,7 @@ import (
 // New returns a new Client.
 func New(cfg config.Config) *Client {
 	return &Client{
-		log: cfg.DebugLog,
+		log: cfg.DebugLogf,
 		client: &http.Client{
 			Timeout: cfg.Client.HTTPTimeout,
 			Transport: &http.Transport{

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,20 +32,21 @@ import (
 )
 
 // New returns a new Client.
-func New(cfg config.Client) *Client {
+func New(cfg config.Config) *Client {
 	return &Client{
+		log: cfg.DebugLog,
 		client: &http.Client{
-			Timeout: cfg.HTTPTimeout,
+			Timeout: cfg.Client.HTTPTimeout,
 			Transport: &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: cfg.DialTimeout,
+					Timeout: cfg.Client.DialTimeout,
 				}).DialContext,
-				MaxIdleConns:          cfg.MaxIdleConns,
-				MaxIdleConnsPerHost:   cfg.MaxIdleConnsPerHost,
-				DisableKeepAlives:     cfg.DisableKeepAlives,
-				IdleConnTimeout:       cfg.IdleConnTimeout,
-				TLSHandshakeTimeout:   cfg.TLSHandshakeTimeout,
-				ResponseHeaderTimeout: cfg.ResponseHeaderTimeout,
+				MaxIdleConns:          cfg.Client.MaxIdleConns,
+				MaxIdleConnsPerHost:   cfg.Client.MaxIdleConnsPerHost,
+				DisableKeepAlives:     cfg.Client.DisableKeepAlives,
+				IdleConnTimeout:       cfg.Client.IdleConnTimeout,
+				TLSHandshakeTimeout:   cfg.Client.TLSHandshakeTimeout,
+				ResponseHeaderTimeout: cfg.Client.ResponseHeaderTimeout,
 			},
 		},
 	}
@@ -53,26 +54,35 @@ func New(cfg config.Client) *Client {
 
 // Client is an HTTP client.
 type Client struct {
+	log    config.Logger
 	client *http.Client
 }
 
 // Get performs an HTTP GET request.
 func (c *Client) Get(ctx context.Context, url string) (*Response, error) {
+	c.log("Performing HTTP GET request to %s", url)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
+		c.log("Error creating HTTP request to %s: %v", url, err)
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
 	res, err := c.client.Do(req)
 	if err != nil {
+		c.log("Error performing HTTP GET request to %s: %v", url, err)
 		return nil, fmt.Errorf("failed to perform HTTP GET request: %w", err)
 	}
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
+		c.log("Error reading response body from %s: %v", url, err)
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+
+	c.log("client: Received response with status code from %s: %d", url, res.StatusCode)
+	c.log("client: Response body from url %s: %s", url, string(body))
 
 	return &Response{res.StatusCode, body}, nil
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -40,7 +40,7 @@ func TestClient_Get_Success(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	cfg := config.Client{}
+	cfg := config.Config{}
 	c := client.New(cfg)
 
 	_, err := c.Get(context.Background(), ts.URL)
@@ -50,7 +50,7 @@ func TestClient_Get_Success(t *testing.T) {
 func TestClient_Get_BuildRequestFailure(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.Client{}
+	cfg := config.Config{}
 	c := client.New(cfg)
 
 	_, err := c.Get(context.Background(), "://invalid-url")
@@ -61,7 +61,7 @@ func TestClient_Get_BuildRequestFailure(t *testing.T) {
 func TestClient_Get_ClientFailure(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.Client{}
+	cfg := config.Config{}
 	c := client.New(cfg)
 
 	_, err := c.Get(context.Background(), "invalid-url")
@@ -82,7 +82,7 @@ func TestClient_Get_ResBodyFailure(t *testing.T) {
 		}
 	}))
 
-	cfg := config.Client{}
+	cfg := config.Config{}
 	c := client.New(cfg)
 
 	_, err := c.Get(context.Background(), ts.URL)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,14 +103,14 @@ type Client struct {
 	ResponseHeaderTimeout time.Duration
 }
 
-// Log logs messages using the configured logger.
+// Logf logs messages using the configured logger.
 func (c Config) Logf(format string, args ...any) {
 	if c.log != nil {
 		c.log(format, args...)
 	}
 }
 
-// DebugLog logs debug messages if debug is enabled.
+// DebugLogf logs debug messages if debug is enabled.
 // Used for verbose logging during development or troubleshooting.
 func (c Config) DebugLogf(format string, args ...any) {
 	if c.debugEnbabled && c.log != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	metaURIEnv      = "ECS_CONTAINER_METADATA_URI_V4"
-	DebugEnabledEnv = "GOMAXECS_DEBUG"
+	debugEnabledEnv = "GOMAXECS_DEBUG"
 	taskPath        = "/task"
 	httpTimeout     = 5
 )
@@ -70,7 +70,7 @@ func New(opts ...Option) Config {
 }
 
 func isDebugEnabled() bool {
-	debugEnabled := os.Getenv(DebugEnabledEnv)
+	debugEnabled := os.Getenv(debugEnabledEnv)
 	return strings.EqualFold(debugEnabled, "true") || debugEnabled == "1"
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,8 +63,8 @@ func New(opts ...Option) Config {
 		cfg.log = log.Printf
 	}
 
-	cfg.DebugLog("Debug logging enabled")
-	cfg.DebugLog("Setup config: %#v", cfg)
+	cfg.DebugLogf("Debug logging enabled")
+	cfg.DebugLogf("Setup config: %#v", cfg)
 
 	return cfg
 }
@@ -104,7 +104,7 @@ type Client struct {
 }
 
 // Log logs messages using the configured logger.
-func (c Config) Log(format string, args ...any) {
+func (c Config) Logf(format string, args ...any) {
 	if c.log != nil {
 		c.log(format, args...)
 	}
@@ -112,7 +112,7 @@ func (c Config) Log(format string, args ...any) {
 
 // DebugLog logs debug messages if debug is enabled.
 // Used for verbose logging during development or troubleshooting.
-func (c Config) DebugLog(format string, args ...any) {
+func (c Config) DebugLogf(format string, args ...any) {
 	if c.debugEnbabled && c.log != nil {
 		c.log("gomaxecs debug: "+format, args...)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,7 @@ func New(opts ...Option) Config {
 		opt(&cfg)
 	}
 
-	// Ensure a logger is set before using DebugLog.
+	// If debug is enabled and no logger is set, use the default log.Printf
 	if cfg.debugEnbabled && cfg.log == nil {
 		cfg.log = log.Printf
 	}
@@ -113,11 +113,7 @@ func (c Config) Log(format string, args ...any) {
 // DebugLog logs debug messages if debug is enabled.
 // Used for verbose logging during development or troubleshooting.
 func (c Config) DebugLog(format string, args ...any) {
-	if c.log == nil {
-		panic("DebugLog called but no logger is set. Ensure to set logger before calling DebugLog.")
-	}
-
-	if c.debugEnbabled {
+	if c.debugEnbabled && c.log != nil {
 		c.log("gomaxecs debug: "+format, args...)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,21 +22,24 @@
 package config
 
 import (
+	"log"
 	"os"
 	"strings"
 	"time"
 )
 
 const (
-	metaURIEnv  = "ECS_CONTAINER_METADATA_URI_V4"
-	taskPath    = "/task"
-	httpTimeout = 5
+	metaURIEnv      = "ECS_CONTAINER_METADATA_URI_V4"
+	DebugEnabledEnv = "GOMAXECS_DEBUG"
+	taskPath        = "/task"
+	httpTimeout     = 5
 )
 
 func New(opts ...Option) Config {
 	uri := GetECSMetadataURI()
 
 	cfg := Config{
+		debugEnbabled:        isDebugEnabled(),
 		TaskMetadataURI:      uri + taskPath,
 		ContainerMetadataURI: uri,
 		Client: Client{
@@ -55,7 +58,20 @@ func New(opts ...Option) Config {
 		opt(&cfg)
 	}
 
+	// Ensure a logger is set before using DebugLog.
+	if cfg.debugEnbabled && cfg.log == nil {
+		cfg.log = log.Printf
+	}
+
+	cfg.DebugLog("Debug logging enabled")
+	cfg.DebugLog("Setup config: %#v", cfg)
+
 	return cfg
+}
+
+func isDebugEnabled() bool {
+	debugEnabled := os.Getenv(DebugEnabledEnv)
+	return strings.EqualFold(debugEnabled, "true") || debugEnabled == "1"
 }
 
 // GetECSMetadataURI returns the ECS metadata URI.
@@ -66,13 +82,14 @@ func GetECSMetadataURI() string {
 
 // Config represents the package configuration.
 type Config struct {
+	debugEnbabled        bool
 	ContainerMetadataURI string
 	TaskMetadataURI      string
 	Client               Client
-	log                  logger
+	log                  Logger
 }
 
-type logger func(format string, args ...any)
+type Logger func(format string, args ...any)
 
 // Client represents the HTTP client configuration.
 type Client struct {
@@ -86,14 +103,27 @@ type Client struct {
 	ResponseHeaderTimeout time.Duration
 }
 
+// Log logs messages using the configured logger.
 func (c Config) Log(format string, args ...any) {
 	if c.log != nil {
 		c.log(format, args...)
 	}
 }
 
+// DebugLog logs debug messages if debug is enabled.
+// Used for verbose logging during development or troubleshooting.
+func (c Config) DebugLog(format string, args ...any) {
+	if c.log == nil {
+		panic("DebugLog called but no logger is set. Ensure to set logger before calling DebugLog.")
+	}
+
+	if c.debugEnbabled {
+		c.log("gomaxecs debug: "+format, args...)
+	}
+}
+
 // WithLogger sets the logger for the config.
-func WithLogger(logger logger) Option {
+func WithLogger(logger Logger) Option {
 	return func(cfg *Config) {
 		cfg.log = logger
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func New(opts ...Option) Config {
 	uri := GetECSMetadataURI()
 
 	cfg := Config{
-		debugEnbabled:        isDebugEnabled(),
+		debugEnabled:         isDebugEnabled(),
 		TaskMetadataURI:      uri + taskPath,
 		ContainerMetadataURI: uri,
 		Client: Client{
@@ -59,7 +59,7 @@ func New(opts ...Option) Config {
 	}
 
 	// If debug is enabled and no logger is set, use the default log.Printf
-	if cfg.debugEnbabled && cfg.log == nil {
+	if cfg.debugEnabled && cfg.log == nil {
 		cfg.log = log.Printf
 	}
 
@@ -82,7 +82,7 @@ func GetECSMetadataURI() string {
 
 // Config represents the package configuration.
 type Config struct {
-	debugEnbabled        bool
+	debugEnabled         bool
 	ContainerMetadataURI string
 	TaskMetadataURI      string
 	Client               Client
@@ -113,7 +113,7 @@ func (c Config) Logf(format string, args ...any) {
 // DebugLogf logs debug messages if debug is enabled.
 // Used for verbose logging during development or troubleshooting.
 func (c Config) DebugLogf(format string, args ...any) {
-	if c.debugEnbabled && c.log != nil {
+	if c.debugEnabled && c.log != nil {
 		c.log("gomaxecs debug: "+format, args...)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,7 +57,7 @@ func TestConfig_WithLogger_LogsMessage(t *testing.T) {
 
 	cfg := config.New(config.WithLogger(logger.Printf))
 
-	cfg.Log("test log: %s, %s", "arg1", "arg2")
+	cfg.Logf("test log: %s, %s", "arg1", "arg2")
 
 	wantLog := "test log: arg1, arg2\n"
 	assert.Equal(t, wantLog, buf.String())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"bytes"
 	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,10 +12,13 @@ import (
 	"github.com/rdforte/gomaxecs/internal/config"
 )
 
+const (
+	metaURIEnvKey = "ECS_CONTAINER_METADATA_URI_V4"
+	metaURIEnvVal = "mock-ecs-metadata-uri/"
+)
+
 func TestConfig_New_LoadConfiguration(t *testing.T) {
-	metaURIEnv := "ECS_CONTAINER_METADATA_URI_V4"
-	uri := "mock-ecs-metadata-uri/"
-	t.Setenv(metaURIEnv, uri)
+	t.Setenv(metaURIEnvKey, metaURIEnvVal)
 
 	cfg := config.New()
 
@@ -64,24 +68,20 @@ func TestConfig_WithLogger_LogsMessage(t *testing.T) {
 }
 
 func TestConfig_GetECSMetadataURI_RetrievesMetadataURIFromEnv(t *testing.T) {
-	metaURIEnv := "ECS_CONTAINER_METADATA_URI_V4"
-	uri := "mock-ecs-metadata-uri/"
-	t.Setenv(metaURIEnv, uri)
+	t.Setenv(metaURIEnvKey, metaURIEnvVal)
 
 	got := config.GetECSMetadataURI()
 
-	want := "mock-ecs-metadata-uri"
+	want := strings.TrimSuffix(metaURIEnvVal, "/")
 	assert.Equal(t, want, got)
 }
 
 func TestConfig_GomaxecsDebugEnv_SetsDebugModeInConfig(t *testing.T) {
-	metaURIEnv := "ECS_CONTAINER_METADATA_URI_V4"
-	uri := "mock-ecs-metadata-uri/"
-	t.Setenv(metaURIEnv, uri)
+	t.Setenv(metaURIEnvKey, metaURIEnvVal)
 
 	got := config.GetECSMetadataURI()
 
-	want := "mock-ecs-metadata-uri"
+	want := strings.TrimSuffix(metaURIEnvVal, "/")
 	assert.Equal(t, want, got)
 }
 
@@ -133,7 +133,8 @@ func TestConfig_DebugLogf_DoesNotLogWhenGomaxecsDebugEnvNotEnabled(t *testing.T)
 
 			cfg.DebugLogf("debug log: %s", "stub-message")
 
-			assert.Equal(t, buf.Len(), 0)
+			gotLen, wantLen := buf.Len(), 0
+			assert.Equal(t, wantLen, gotLen)
 		})
 	}
 }
@@ -147,6 +148,7 @@ func TestConfig_DebugLogf_UsesDefaultLoggerWhenDebugEnabledAndNoLoggerSet(t *tes
 	// replace the original log.Printf with one that writes to our buffer
 	originalLogger := log.Default()
 	originalOutput := originalLogger.Writer()
+
 	log.SetOutput(buf)
 	defer log.SetOutput(originalOutput)
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,6 +74,70 @@ func TestConfig_GetECSMetadataURI_RetrievesMetadataURIFromEnv(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestConfig_GomaxecsDebugEnv_SetsDebugModeInConfig(t *testing.T) {
+	metaURIEnv := "ECS_CONTAINER_METADATA_URI_V4"
+	uri := "mock-ecs-metadata-uri/"
+	t.Setenv(metaURIEnv, uri)
+
+	got := config.GetECSMetadataURI()
+
+	want := "mock-ecs-metadata-uri"
+	assert.Equal(t, want, got)
+}
+
+func TestConfig_DebugLogf_LogsWhenGomaxecsDebugEnvEnabled(t *testing.T) {
+	tableTest := []struct {
+		env string
+	}{
+		{env: "true"},
+		{env: "1"},
+	}
+
+	for _, tt := range tableTest {
+		t.Run("GOMAXECS_DEBUG="+tt.env, func(t *testing.T) {
+			t.Setenv("GOMAXECS_DEBUG", tt.env)
+
+			buf := new(bytes.Buffer)
+			logger := log.New(buf, "", 0)
+
+			cfg := config.New(config.WithLogger(logger.Printf))
+
+			// clear buffer so we only have fresh logs
+			buf.Reset()
+
+			cfg.DebugLogf("debug log: %s", "stub-message")
+
+			wantLog := "gomaxecs debug: debug log: stub-message\n"
+			assert.Equal(t, wantLog, buf.String())
+		})
+	}
+}
+
+func TestConfig_DebugLogf_DoesNotLogWhenGomaxecsDebugEnvNotEnabled(t *testing.T) {
+	tableTest := []struct {
+		env string
+	}{
+		{env: "false"},
+		{env: "0"},
+		{env: ""},
+	}
+
+	for _, tt := range tableTest {
+		t.Run("GOMAXECS_DEBUG="+tt.env, func(t *testing.T) {
+			t.Setenv("GOMAXECS_DEBUG", tt.env)
+
+			buf := new(bytes.Buffer)
+			logger := log.New(buf, "", 0)
+
+			cfg := config.New(config.WithLogger(logger.Printf))
+
+			cfg.DebugLogf("debug log: %s", "stub-message")
+
+			assert.Equal(t, buf.Len(), 0)
+		})
+	}
+}
+
 type mockOption struct {
 	isApplied bool
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,6 +138,29 @@ func TestConfig_DebugLogf_DoesNotLogWhenGomaxecsDebugEnvNotEnabled(t *testing.T)
 	}
 }
 
+// write test that checks that default log.Printf is used when debug enabled and no logger set.
+func TestConfig_DebugLogf_UsesDefaultLoggerWhenDebugEnabledAndNoLoggerSet(t *testing.T) {
+	t.Setenv("GOMAXECS_DEBUG", "true")
+
+	buf := new(bytes.Buffer)
+
+	// replace the original log.Printf with one that writes to our buffer
+	originalLogger := log.Default()
+	originalOutput := originalLogger.Writer()
+	log.SetOutput(buf)
+	defer log.SetOutput(originalOutput)
+
+	cfg := config.New()
+
+	// clear buffer so we only have fresh logs
+	buf.Reset()
+
+	cfg.DebugLogf("debug log: %s", "stub-message")
+
+	wantLog := "gomaxecs debug: debug log: stub-message\n"
+	assert.Contains(t, buf.String(), wantLog)
+}
+
 type mockOption struct {
 	isApplied bool
 }

--- a/internal/task/meta.go
+++ b/internal/task/meta.go
@@ -50,6 +50,7 @@ type limit struct {
 // Grab the container metadata from the ECS Metadata endpoint.
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-examples.html
 func (t *Task) getContainerMeta(ctx context.Context) (container, error) {
+	t.log("Fetching container metadata from %s", t.containerMetadataURI)
 	return getMeta[container](ctx, t.client, t.containerMetadataURI)
 }
 
@@ -58,6 +59,7 @@ func (t *Task) getContainerMeta(ctx context.Context) (container, error) {
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4-examples.html
 // #task-metadata-endpoint-v4-example-task-metadata-response.
 func (t *Task) getTaskMeta(ctx context.Context) (taskMeta, error) {
+	t.log("Fetching task metadata from %s", t.taskMetadataURI)
 	return getMeta[taskMeta](ctx, t.client, t.taskMetadataURI)
 }
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -53,7 +53,7 @@ func New(cfg config.Config) *Task {
 		cfg.ContainerMetadataURI,
 		client.New(cfg),
 		// use the debug logger as we only want to show logs in task when debug enabled.
-		cfg.DebugLog,
+		cfg.DebugLogf,
 	}
 }
 
@@ -70,7 +70,7 @@ func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("failed to get ECS container meta: %w", err)
 	}
 
-	t.log("Recieved container metadata: %#v", container)
+	t.log("Received container metadata: %#v", container)
 
 	task, err := t.getTaskMeta(ctx)
 	if err != nil {
@@ -78,7 +78,7 @@ func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("failed to get ECS task meta: %w", err)
 	}
 
-	t.log("Recieved task metadata: %#v", container)
+	t.log("Received task metadata: %#v", container)
 
 	// Either the container limit or the task limit must be set
 	if container.Limits.CPU == 0 && task.Limits.CPU == 0 {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -78,7 +78,7 @@ func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("failed to get ECS task meta: %w", err)
 	}
 
-	t.log("Received task metadata: %#v", container)
+	t.log("Received task metadata: %#v", task)
 
 	// Either the container limit or the task limit must be set
 	if container.Limits.CPU == 0 && task.Limits.CPU == 0 {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -43,6 +43,7 @@ type Task struct {
 	taskMetadataURI      string
 	containerMetadataURI string
 	client               *client.Client
+	log                  config.Logger
 }
 
 // New returns a new Task.
@@ -50,7 +51,9 @@ func New(cfg config.Config) *Task {
 	return &Task{
 		cfg.TaskMetadataURI,
 		cfg.ContainerMetadataURI,
-		client.New(cfg.Client),
+		client.New(cfg),
+		// use the debug logger as we only want to show logs in task when debug enabled.
+		cfg.DebugLog,
 	}
 }
 
@@ -63,16 +66,23 @@ func New(cfg config.Config) *Task {
 func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 	container, err := t.getContainerMeta(ctx)
 	if err != nil {
+		t.log("Error getting container metadata: %v", err)
 		return 0, fmt.Errorf("failed to get ECS container meta: %w", err)
 	}
 
+	t.log("Recieved container metadata: %#v", container)
+
 	task, err := t.getTaskMeta(ctx)
 	if err != nil {
+		t.log("Error getting task metadata: %v", err)
 		return 0, fmt.Errorf("failed to get ECS task meta: %w", err)
 	}
 
+	t.log("Recieved task metadata: %#v", container)
+
 	// Either the container limit or the task limit must be set
 	if container.Limits.CPU == 0 && task.Limits.CPU == 0 {
+		t.log("No CPU limit found for container or task")
 		return 0, errNoCPULimit
 	}
 
@@ -80,20 +90,27 @@ func (t *Task) GetMaxProcs(ctx context.Context) (int, error) {
 
 	for _, taskContainer := range task.Containers {
 		if container.DockerID == taskContainer.DockerID {
+			t.log("Matched container DockerID %s to task container DockerID %s", container.DockerID, taskContainer.DockerID)
+			t.log("Container CPU limit: %f", taskContainer.Limits.CPU)
 			containerCPULimit = taskContainer.Limits.CPU
 		}
 	}
 
 	if containerCPULimit == 0 {
+		t.log("No matching container CPU limit found; using task CPU limit %f", task.Limits.CPU)
 		return max(int(task.Limits.CPU), minCPU), nil
 	}
 
 	cpu := max(int(containerCPULimit)>>cpuUnits, minCPU)
+	t.log("Calculated container CPU limit: %d", cpu)
 
 	taskCPULimit := int(task.Limits.CPU)
 	if taskCPULimit > 0 {
+		t.log("Comparing container CPU limit %d with task CPU limit %d", cpu, taskCPULimit)
 		return min(taskCPULimit, cpu), nil
 	}
+
+	t.log("Using container CPU limit %d as task CPU limit is not set", cpu)
 
 	return cpu, nil
 }

--- a/internal/task/tasktest/tasktest.go
+++ b/internal/task/tasktest/tasktest.go
@@ -36,7 +36,7 @@ func (e *ECSAgent) WithContainerMetaEndpoint(containerCPU int) *ECSAgent {
 	e.t.Helper()
 
 	e.mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(fmt.Sprintf(`{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)))
+		_, err := fmt.Fprintf(w, `{"Limits":{"CPU":%d},"DockerId":"container-id"}`, containerCPU)
 		assert.NoError(e.t, err)
 	})
 
@@ -48,11 +48,12 @@ func (e *ECSAgent) WithTaskMetaEndpoint(containerCPU, taskCPU int) *ECSAgent {
 	e.t.Helper()
 
 	e.mux.HandleFunc("/task", func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(fmt.Sprintf(
+		_, err := fmt.Fprintf(
+			w,
 			`{"Containers":[{"DockerId":"container-id","Limits":{"CPU":%d}}],"Limits":{"CPU":%d}}`,
 			containerCPU,
 			taskCPU,
-		)))
+		)
 		assert.NoError(e.t, err)
 	})
 

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -15,21 +15,30 @@ const maxProcsKey = "GOMAXPROCS"
 // Set sets GOMAXPROCS based on the CPU limit of the container and the task.
 // returns a function to reset GOMAXPROCS to its previous value and an error if one occurred.
 // If the GOMAXPROCS environment variable is set, it will honor that value.
-func Set(opts ...config.Option) (func(), error) {
+func Set(opts ...config.Option) (undo func(), err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("maxprocs: panic occurred while setting GOMAXPROCS: %v", r)
+		}
+		if undo == nil {
+			undo = func() {}
+		}
+	}()
+
 	cfg := config.New(opts...)
 	task := ecstask.New(cfg)
 
-	undoNoop := func() {
+	undo = func() {
 		cfg.Log("maxprocs: No GOMAXPROCS change to reset")
 	}
 
 	if procs, ok := shouldHonorGOMAXPROCSEnv(); ok {
 		cfg.Log("maxprocs: Honoring GOMAXPROCS=%q as set in environment", procs)
-		return undoNoop, nil
+		return undo, nil
 	}
 
 	prevProcs := prevMaxProcs()
-	undo := func() {
+	undo = func() {
 		cfg.Log("maxprocs: Resetting GOMAXPROCS to %v", prevProcs)
 		setMaxProcs(prevProcs)
 	}
@@ -39,6 +48,8 @@ func Set(opts ...config.Option) (func(), error) {
 		cfg.Log("maxprocs: Failed to set GOMAXPROCS:", err)
 		return undo, fmt.Errorf("failed to set GOMAXPROCS: %w", err)
 	}
+
+	cfg.DebugLog("Calculated GOMAXPROCS to be %d", procs)
 
 	setMaxProcs(procs)
 	cfg.Log("maxprocs: Updated GOMAXPROCS=%v", procs)

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -49,7 +49,7 @@ func Set(opts ...config.Option) (undo func(), err error) {
 
 	procs, err := task.GetMaxProcs(context.Background())
 	if err != nil {
-		cfg.Logf("maxprocs: Failed to set GOMAXPROCS:", err)
+		cfg.Logf("maxprocs: Failed to set GOMAXPROCS: %v", err)
 		return undo, fmt.Errorf("failed to set GOMAXPROCS: %w", err)
 	}
 

--- a/maxprocs/maxprocs.go
+++ b/maxprocs/maxprocs.go
@@ -2,6 +2,7 @@ package maxprocs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -12,14 +13,17 @@ import (
 
 const maxProcsKey = "GOMAXPROCS"
 
+var errPanic = errors.New("maxprocs: panic occurred while setting GOMAXPROCS")
+
 // Set sets GOMAXPROCS based on the CPU limit of the container and the task.
 // returns a function to reset GOMAXPROCS to its previous value and an error if one occurred.
 // If the GOMAXPROCS environment variable is set, it will honor that value.
 func Set(opts ...config.Option) (undo func(), err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("maxprocs: panic occurred while setting GOMAXPROCS: %v", r)
+			err = fmt.Errorf("%w: %v", errPanic, r)
 		}
+
 		if undo == nil {
 			undo = func() {}
 		}
@@ -29,30 +33,30 @@ func Set(opts ...config.Option) (undo func(), err error) {
 	task := ecstask.New(cfg)
 
 	undo = func() {
-		cfg.Log("maxprocs: No GOMAXPROCS change to reset")
+		cfg.Logf("maxprocs: No GOMAXPROCS change to reset")
 	}
 
 	if procs, ok := shouldHonorGOMAXPROCSEnv(); ok {
-		cfg.Log("maxprocs: Honoring GOMAXPROCS=%q as set in environment", procs)
+		cfg.Logf("maxprocs: Honoring GOMAXPROCS=%q as set in environment", procs)
 		return undo, nil
 	}
 
 	prevProcs := prevMaxProcs()
 	undo = func() {
-		cfg.Log("maxprocs: Resetting GOMAXPROCS to %v", prevProcs)
+		cfg.Logf("maxprocs: Resetting GOMAXPROCS to %v", prevProcs)
 		setMaxProcs(prevProcs)
 	}
 
 	procs, err := task.GetMaxProcs(context.Background())
 	if err != nil {
-		cfg.Log("maxprocs: Failed to set GOMAXPROCS:", err)
+		cfg.Logf("maxprocs: Failed to set GOMAXPROCS:", err)
 		return undo, fmt.Errorf("failed to set GOMAXPROCS: %w", err)
 	}
 
-	cfg.DebugLog("Calculated GOMAXPROCS to be %d", procs)
+	cfg.DebugLogf("Calculated GOMAXPROCS to be %d", procs)
 
 	setMaxProcs(procs)
-	cfg.Log("maxprocs: Updated GOMAXPROCS=%v", procs)
+	cfg.Logf("maxprocs: Updated GOMAXPROCS=%v", procs)
 
 	return undo, nil
 }

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/rdforte/gomaxecs/internal/config"
 	"github.com/rdforte/gomaxecs/internal/task/tasktest"
 	"github.com/rdforte/gomaxecs/maxprocs"
 )
@@ -160,4 +161,20 @@ func TestMaxProcs_IsECS_ReturnsTrueIfDetectedECSEnvironment(t *testing.T) {
 
 func TestMaxProcs_IsECS_ReturnsFalseIfNotDetectedECSEnvironment(t *testing.T) {
 	assert.False(t, maxprocs.IsECS())
+}
+
+func TestMaxProcs_ShouldCapturePanic_ReturnsErrorOnPanic(t *testing.T) {
+	panicOption := func(cfg *config.Config) {
+		panic("simulated panic")
+	}
+
+	undo, err := maxprocs.Set(panicOption)
+
+	require.Error(t, err)
+	assert.Contains(t,
+		err.Error(),
+		"panic occurred while setting GOMAXPROCS",
+	)
+
+	assert.NotNil(t, undo)
 }

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -164,7 +164,7 @@ func TestMaxProcs_IsECS_ReturnsFalseIfNotDetectedECSEnvironment(t *testing.T) {
 }
 
 func TestMaxProcs_ShouldCapturePanic_ReturnsErrorOnPanic(t *testing.T) {
-	panicOption := func(cfg *config.Config) {
+	panicOption := func(_ *config.Config) {
 		panic("simulated panic")
 	}
 

--- a/maxprocs/maxprocs_test.go
+++ b/maxprocs/maxprocs_test.go
@@ -177,4 +177,5 @@ func TestMaxProcs_ShouldCapturePanic_ReturnsErrorOnPanic(t *testing.T) {
 	)
 
 	assert.NotNil(t, undo)
+	assert.IsType(t, func() {}, undo)
 }


### PR DESCRIPTION
This PR is to help aid in solving the following issue https://github.com/rdforte/gomaxecs/issues/14

There are a few additions/changes:

**Addition 1**
setting the following environment variable while using the package will increase the logging verbosity and number of logs to help with debugging and triaging issues.
```
GOMAXECS_DEBUG=true
```
or
```
GOMAXECS_DEBUG=1
```

**Addition 2**
Bump the go version in go.mod to `1.25`

**Addition 3**
migrate [golangci-lint](https://golangci-lint.run) to the latest version

**Addition 4**
Adds defer to `Set` method for recovering from panic.

**Addition 5**
Upgrade actions in build pipeline
